### PR TITLE
fix(app): strip NUL + C0 control chars in _safe_md_inline (Cycle 1.5 F-9.6.1)

### DIFF
--- a/src/ciguard/app/checks.py
+++ b/src/ciguard/app/checks.py
@@ -78,14 +78,24 @@ def _safe_md_inline(value: Optional[str], *, max_len: int = INLINE_MAX_CHARS) ->
     don't fully trust (built-in messages are safe; LLM-enriched ones
     may not be), human-readable severities echoed back from input.
 
-    Strips CR/LF + tab; escapes markdown specials; caps length;
-    HTML-encodes `<` and `>` to defeat raw-HTML injection in markdown.
+    Strips CR/LF + tab + ASCII NUL + remaining C0 control chars; escapes
+    markdown specials; caps length; HTML-encodes `<` and `>` to defeat
+    raw-HTML injection in markdown.
+
+    NUL-byte handling closes Cycle 1.5 finding F-9.6.1 (CWE-158): an
+    attacker-supplied NUL inside an inline value would otherwise traverse
+    the sanitiser unchanged and could truncate downstream consumers
+    (logs, search indices, custom CI tooling) that treat \\x00 as a
+    string terminator while GitHub's PR renderer normalises it on display.
     """
     if value is None:
         return "_(none)_"
     safe = (
         value.replace("\r", " ").replace("\n", " ").replace("\t", " ")
     )
+    # Strip ASCII NUL + all other C0 control chars (\x01-\x1f minus the
+    # CR/LF/tab already turned into spaces). \x7f DEL is also stripped.
+    safe = "".join(ch for ch in safe if ord(ch) >= 0x20 and ord(ch) != 0x7f)
     # HTML-encode angle brackets first (markdown lets raw HTML through).
     safe = safe.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     # Backslash-escape every markdown special so links / emphasis can't

--- a/tests/regression/cycle1.5/F-9.6.1-null-byte-inline.py
+++ b/tests/regression/cycle1.5/F-9.6.1-null-byte-inline.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regression: F-9.6.1 — `_safe_md_inline` must strip ASCII NUL bytes.
+
+Originally surfaced by Cycle 1.5 self-pentest 2026-05-03. Fixed in v0.11.0-1.5fix.
+
+PoC contract:
+- The exploit input is a string with embedded ASCII NUL bytes.
+- The exploit is "succeeded" if `_safe_md_inline()` returns a string still
+  containing `\\x00` (i.e. CWE-158 vulnerability remains open).
+- The exploit is "failed" if `_safe_md_inline()` strips the NULs.
+
+Convention: exit 0 = exploit FAILED (fix held); exit 1 = exploit SUCCEEDED (regression).
+"""
+import sys
+
+from ciguard.app import checks
+
+
+def main() -> int:
+    cases = [
+        "before\x00middle\x00after",
+        "\x00leading-null",
+        "trailing-null\x00",
+        "all-c0-controls\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1fend",
+        "del-byte\x7fend",
+    ]
+
+    fail = 0
+    for raw in cases:
+        out = checks._safe_md_inline(raw)
+        leaked = any(c == "\x00" for c in out) or any(0x01 <= ord(c) <= 0x1f for c in out) or "\x7f" in out
+        verdict = "FAIL — exploit succeeded, control char leaked" if leaked else "PASS — fix held"
+        print(f"  in={raw!r}\n    out={out!r}\n    {verdict}")
+        if leaked:
+            fail += 1
+
+    print()
+    if fail:
+        print(f"EXPLOIT SUCCEEDED ({fail}/{len(cases)} cases) — regression: F-9.6.1 has reopened.")
+        return 1
+    print(f"EXPLOIT FAILED ({len(cases)} cases) — F-9.6.1 fix is in place.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/regression/cycle1.5/README.md
+++ b/tests/regression/cycle1.5/README.md
@@ -1,0 +1,39 @@
+# Cycle 1.5 regression suite
+
+Permanent automated tests for findings closed during ciguard Pentest Cycle 1.5
+(2026-05-03 against v0.11.0). Each file is a self-contained PoC that returns
+**exit 0 if the fix held** and **exit 1 if the exploit succeeded** (regression).
+
+## How to run
+
+```sh
+cd /path/to/ciguard
+python -m pip install -e ".[app,mcp]"
+for f in tests/regression/cycle1.5/F-*.py; do
+  echo "=== $f ==="
+  python "$f" || echo "REGRESSION DETECTED"
+done
+```
+
+CI runs the same loop on every push (see `.github/workflows/ci.yml`).
+
+## Findings tracked here
+
+| ID      | Title                                              | Severity | Fixed in     |
+|---------|----------------------------------------------------|----------|--------------|
+| F-9.6.1 | `_safe_md_inline` must strip ASCII NUL + C0 chars  | Low      | v0.11.0-1.5fix |
+
+The Info-level F-9.1.1 finding (permissive ASCII OWS in `X-Hub-Signature-256`
+header) is **not** tracked here — disposition is "GitHub issue, optional
+hardening" per Cycle 1.5 final report §4.2.
+
+## Convention
+
+- One file per finding ID.
+- Filename: `F-<row>.<n>-<kebab-case-summary>.py` (or `.sh` for shell PoCs).
+- Exit 0 = fix held; exit 1 = regression. **Inverted** from the Cycle-1
+  convention where exit 1 meant "fix held" — Cycle 1.5 standardises on the
+  more-conventional "exit 0 = test passed".
+- PoC body must produce on-disk evidence is NOT required here (these are CI
+  regression tests, not engagement-letter-grade evidence captures); but each
+  PoC prints clear PASS/FAIL markers per case so log triage is unambiguous.


### PR DESCRIPTION
## Summary

- Closes Cycle 1.5 finding **F-9.6.1** (Low, CVSS 3.7, CWE-158): `_safe_md_inline()` previously left ASCII NUL + remaining C0 control chars intact in attacker-controlled inline values (rule_id, location, brief metadata). One-line comprehension after the existing CR/LF/tab strip now drops every char with `ord(c) < 0x20` plus `0x7f` DEL.
- Adds `tests/regression/cycle1.5/F-9.6.1-null-byte-inline.py` (5 sub-cases) and `tests/regression/cycle1.5/README.md` (convention notes).

## Why now

ciguard Pentest Cycle 1.5 (2026-05-03) — the App self-pentest gate before the GitHub App goes publicly installable — surfaced this as one of two findings (the other being F-9.1.1, an Info-level OWS observation that doesn't need code changes). Full report at `Project ciguard/Pentest Reports/2026-05-03-cycle-1.5.md` in the planning vault.

## Severity assessment

CVSS v3.1: `AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N` ≈ **3.7 Low**.

Exploit path is narrow — GitHub's PR renderer normalises C0 controls on display, but downstream consumers (logs, search indices, custom CI tooling) commonly treat `\x00` as a string terminator and could see a truncated form while the rendered comment shows the full string. `_safe_md_block()` (the 4-backtick fenced sibling) already handled NULs correctly via the fence wrapping, so only the inline path needed touching.

## Disclosure decision

**No GHSA filed.** Per the cycle's same-day-disclosure rationale: verified ~zero installs at the time of testing (the test App `ciguard-bleeblue-1.5` was the only installation, on the asset-owner's own GitHub account). Cycle 1.5 fires *before* the public install link, so coordinated-disclosure window is moot. Recorded in the cycle's Phase 7 closeout doc.

## Test plan

- [x] `pytest tests/test_app_checks.py` — 34/34 PASS (pre-existing `_safe_md_inline` tests unchanged)
- [x] `pytest` (full suite) — 962 passed, 5 skipped (matches v0.11.0 baseline)
- [x] `python tests/regression/cycle1.5/F-9.6.1-null-byte-inline.py` — exit 0, "EXPLOIT FAILED (5 cases) — F-9.6.1 fix is in place"
- [ ] CI green on this PR

## Release plan

Folds into v0.11.1 alongside the substantive scan-execution-against-clone work (the v0.11.0 stub-scan path is one half of the receiver; v0.11.1 lands the other half + this fix in one bundle).