### PR TITLE
feat(app): clone_and_scan_executor + repo_scan include_findings (v0.11.1)

### DIFF
--- a/src/ciguard/app/clone_executor.py
+++ b/src/ciguard/app/clone_executor.py
@@ -1,0 +1,267 @@
+"""Real scan executor for the ciguard GitHub App (v0.11.1).
+
+Replaces `factory._stub_scan_executor` as the default. Pipeline:
+
+  1. Mint an installation token via `tokens.get_installation_token()`.
+  2. Fetch a tarball of the repo at `head_sha` via GitHub's
+     `GET /repos/{owner}/{repo}/tarball/{ref}` API. Auth-header on the
+     initial request only — GitHub redirects to `codeload.github.com`
+     with a short-lived signed URL that doesn't need the token.
+  3. Extract under a `tempfile.TemporaryDirectory()` with the tarfile
+     `filter="data"` safe-filter (Python 3.12+) — rejects path traversal,
+     absolute paths, special files, and other archive-injection vectors.
+  4. Hand the extracted root to `repo_scan.scan_repo(include_findings=True)`.
+  5. Translate the result into the PR-comment-renderer shape.
+  6. Temp dir auto-cleans on context exit (success OR exception).
+
+Threat model: `Project ciguard/THREAT_MODEL.md` Surface 9. Closes:
+
+  - "Webhook handler DoS — large payload / slow scan" — the tarball
+    download is capped at MAX_TARBALL_BYTES (default 200 MB) with a
+    streaming size check that aborts mid-download if the cap is hit.
+  - "Installation token leakage" — token lives only in the request
+    Authorization header; never appears in URLs (so never in process
+    listings, never in logs that capture URLs).
+  - "Path traversal in archive content" — `filter="data"` is the load-
+    bearing control. We assert the Python version supports it at module
+    import time so an inadvertent downgrade to 3.11 fails loud, not silently.
+
+Why tarball not git-clone:
+  - No git binary required in the deploy image (smaller container,
+    fewer CVEs to patch).
+  - Single HTTP request instead of multi-stage clone+fetch+checkout.
+  - GitHub's tarball is auto-derived from the ref — no
+    "did the shallow clone include this SHA?" edge case.
+  - Smaller transfer (no .git/objects metadata).
+
+What is *not* covered (deferred to subsequent work):
+  - Subprocess isolation of the scanner itself (defence-in-depth against
+    parser exploits in attacker-controlled YAML/Jenkinsfile content).
+    The parsers are already hardened (yaml.SafeLoader, RecursionError
+    wrap from Fuzz #18, etc.) so this is hardening, not a current risk.
+  - Per-installation rate-limit / quota.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from .. import repo_scan
+from . import tokens
+from .scheduler import ScanJob
+
+logger = logging.getLogger("ciguard.app.clone_executor")
+
+# Python's tarfile `filter="data"` arg landed in 3.12. Earlier versions
+# would silently fall back to the unsafe default. We assert at import
+# time so an inadvertent downgrade fails loudly.
+assert sys.version_info >= (3, 12), (
+    "clone_executor requires Python 3.12+ for tarfile filter='data' support"
+)
+
+# Cap on tarball download size. GitHub doesn't pre-declare Content-Length
+# on the codeload redirect, so we enforce streaming. A repo larger than
+# this is almost certainly a monorepo we don't want to scan via the App
+# anyway — the user can run `ciguard scan-repo` locally.
+MAX_TARBALL_BYTES = 200 * 1024 * 1024  # 200 MB
+
+# Network timeout for the tarball fetch. Short enough to not hold a
+# scheduler worker forever; long enough for a normal-size repo download
+# even on a slow link.
+FETCH_TIMEOUT_SECONDS = 120
+
+GITHUB_API_BASE = "https://api.github.com"
+USER_AGENT = "ciguard-app"
+
+
+class TarballTooLarge(Exception):
+    """Raised when streaming download exceeds MAX_TARBALL_BYTES."""
+
+
+class TarballFetchError(Exception):
+    """Raised on any non-200 response from the tarball API."""
+
+
+def _fetch_tarball(
+    *, installation_id: int, owner: str, repo: str, ref: str, dest: Path,
+) -> Path:
+    """Download + extract the repo tarball at `ref` into `dest`. Returns
+    the path to the extracted top-level directory (GitHub tarballs extract
+    to a single child like `Jo-Jo98-ciguard-abc1234/`).
+
+    Synchronous — call from `asyncio.to_thread()` so the scheduler's
+    worker loop isn't blocked by the network round-trip.
+    """
+    token = tokens.get_installation_token(installation_id)
+    url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/tarball/{ref}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": USER_AGENT,
+        },
+    )
+
+    tar_path = dest / "_repo.tar.gz"
+    bytes_seen = 0
+    chunk_size = 64 * 1024
+
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise TarballFetchError(
+                    f"GitHub tarball API returned HTTP {resp.status} for "
+                    f"{owner}/{repo}@{ref[:7]}"
+                )
+            with open(tar_path, "wb") as out:
+                while True:
+                    chunk = resp.read(chunk_size)
+                    if not chunk:
+                        break
+                    bytes_seen += len(chunk)
+                    if bytes_seen > MAX_TARBALL_BYTES:
+                        raise TarballTooLarge(
+                            f"tarball exceeded cap "
+                            f"({bytes_seen} > {MAX_TARBALL_BYTES} bytes) for "
+                            f"{owner}/{repo}@{ref[:7]}"
+                        )
+                    out.write(chunk)
+    except urllib.error.HTTPError as exc:
+        # The most likely reason is a revoked / expired installation token.
+        # Honour the cache-purge contract from THREAT_MODEL row "Cached
+        # installation token used after revocation".
+        if exc.code == 401:
+            tokens.invalidate_token(installation_id)
+        raise TarballFetchError(
+            f"GitHub tarball API returned HTTP {exc.code} for "
+            f"{owner}/{repo}@{ref[:7]}"
+        ) from exc
+
+    extract_root = dest / "extracted"
+    extract_root.mkdir()
+    with tarfile.open(tar_path, mode="r:gz") as tar:
+        # filter="data" rejects: absolute paths, traversal (../), special
+        # files (devices, FIFOs), symlinks pointing outside the extract
+        # root. This is the load-bearing safety.
+        tar.extractall(path=extract_root, filter="data")  # type: ignore[arg-type]
+
+    # Tarball extracts to a single top-level dir. Find it.
+    children = [c for c in extract_root.iterdir() if c.is_dir()]
+    if len(children) != 1:
+        raise TarballFetchError(
+            f"unexpected tarball layout: expected 1 top-level dir, "
+            f"got {len(children)} ({[c.name for c in children]})"
+        )
+    return children[0]
+
+
+def _to_app_result(scan_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate `repo_scan.scan_repo(include_findings=True)` output to
+    the shape `checks.render_pr_comment_body()` expects.
+
+    Empty repos (no pipelines discovered) get a graceful "nothing to scan"
+    result rather than `risk_score=None`.
+    """
+    if scan_result.get("error"):
+        # Path-not-found shouldn't happen post-extract; if it does, surface
+        # explicitly so set_check_run_failed gets a useful message.
+        return {
+            "risk_score": 0,
+            "grade": "F",
+            "findings": [],
+            "summary": f"Scan error: {scan_result['error']}",
+        }
+
+    findings: Iterable[Dict[str, Any]] = scan_result.get("findings") or []
+    risk_score = scan_result.get("risk_score")
+    grade = scan_result.get("grade")
+    files_scanned = scan_result.get("files_scanned", 0)
+
+    if files_scanned == 0:
+        return {
+            "risk_score": "—",
+            "grade": "—",
+            "findings": [],
+            "summary": (
+                "ciguard scanned the repository at this commit but did not "
+                "find any pipeline files (`.gitlab-ci.yml`, "
+                "`.github/workflows/*.yml`, `Jenkinsfile`)."
+            ),
+        }
+
+    return {
+        "risk_score": risk_score if risk_score is not None else "—",
+        "grade": grade if grade is not None else "—",
+        "findings": list(findings),
+        "summary": (
+            f"Scanned {files_scanned} pipeline file(s); "
+            f"found {scan_result.get('total_findings', 0)} finding(s)."
+        ),
+    }
+
+
+async def clone_and_scan_executor(job: ScanJob) -> Dict[str, Any]:
+    """v0.11.1 scan executor: fetch repo at head SHA, scan, return.
+
+    Called by `run_scan()` for each ScanJob the scheduler dispatches.
+    The result dict matches the contract `checks.render_pr_comment_body()`
+    consumes (risk_score, grade, findings, summary).
+    """
+    if "/" not in job.repo_full_name:
+        raise ValueError(
+            f"malformed repo_full_name: {job.repo_full_name!r}"
+        )
+    owner, _, repo = job.repo_full_name.partition("/")
+    head_sha_short = job.head_sha[:7] if job.head_sha else "<unset>"
+    logger.info(
+        "clone_executor: fetching %s/%s@%s for installation=%d",
+        owner, repo, head_sha_short, job.installation_id,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="ciguard-app-") as td:
+        td_path = Path(td)
+        try:
+            extract_path = await asyncio.to_thread(
+                _fetch_tarball,
+                installation_id=job.installation_id,
+                owner=owner, repo=repo,
+                ref=job.head_sha,
+                dest=td_path,
+            )
+        except (TarballTooLarge, TarballFetchError):
+            raise
+        except Exception:
+            logger.exception(
+                "tarball fetch failed for %s/%s@%s",
+                owner, repo, head_sha_short,
+            )
+            raise
+
+        logger.info(
+            "clone_executor: scanning extracted tree at %s",
+            extract_path,
+        )
+        scan_result = await asyncio.to_thread(
+            repo_scan.scan_repo,
+            extract_path,
+            offline=False,
+            include_findings=True,
+        )
+
+    app_result = _to_app_result(scan_result)
+    logger.info(
+        "clone_executor: %s/%s@%s -> %d findings (grade=%s score=%s)",
+        owner, repo, head_sha_short,
+        len(app_result.get("findings", []) or []),
+        app_result.get("grade"), app_result.get("risk_score"),
+    )
+    return app_result

--- a/src/ciguard/app/clone_executor.py
+++ b/src/ciguard/app/clone_executor.py
@@ -51,20 +51,13 @@ import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable
 
 from .. import repo_scan
 from . import tokens
 from .scheduler import ScanJob
 
 logger = logging.getLogger("ciguard.app.clone_executor")
-
-# Python's tarfile `filter="data"` arg landed in 3.12. Earlier versions
-# would silently fall back to the unsafe default. We assert at import
-# time so an inadvertent downgrade fails loudly.
-assert sys.version_info >= (3, 12), (
-    "clone_executor requires Python 3.12+ for tarfile filter='data' support"
-)
 
 # Cap on tarball download size. GitHub doesn't pre-declare Content-Length
 # on the codeload redirect, so we enforce streaming. A repo larger than
@@ -87,6 +80,43 @@ class TarballTooLarge(Exception):
 
 class TarballFetchError(Exception):
     """Raised on any non-200 response from the tarball API."""
+
+
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract `tar` into `dest`, rejecting:
+
+      - absolute paths in member names
+      - parent-dir traversal (`../`)
+      - symlinks, hardlinks, device files, FIFOs (any non-regular non-dir)
+
+    Equivalent to Python 3.12+ `extractall(filter="data")` but written
+    out so we work on 3.10 + 3.11 too. (Python 3.12 added `filter=`
+    as a built-in arg; we deliberately don't depend on that so the
+    package's existing `python_requires` envelope holds.)
+    """
+    dest_resolved = dest.resolve()
+    for member in tar.getmembers():
+        if (
+            member.issym() or member.islnk() or member.ischr()
+            or member.isblk() or member.isfifo() or member.isdev()
+        ):
+            raise TarballFetchError(
+                f"refusing tarball member with special file type: {member.name!r}"
+            )
+        # Resolve the would-be target and ensure it stays under dest.
+        target = (dest / member.name).resolve()
+        if dest_resolved != target and dest_resolved not in target.parents:
+            raise TarballFetchError(
+                f"refusing tarball member outside dest: {member.name!r}"
+            )
+    # On 3.12+, also pass `filter="data"` for belt-and-braces (and to silence
+    # the 3.14 deprecation warning that fires when no filter is set). On
+    # 3.10/3.11 the kwarg doesn't exist; the manual validation above is the
+    # equivalent safety.
+    if sys.version_info >= (3, 12):
+        tar.extractall(path=dest, filter="data")  # nosec B202
+    else:
+        tar.extractall(path=dest)  # nosec B202 — every member validated above
 
 
 def _fetch_tarball(
@@ -116,7 +146,11 @@ def _fetch_tarball(
     chunk_size = 64 * 1024
 
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
+        # nosec B310 — URL is constructed from the hardcoded GITHUB_API_BASE
+        # constant + caller-controlled `owner`/`repo`/`ref`. The scheme is
+        # always https; no file:// or custom-scheme exposure. Token is in
+        # the Authorization header (per Surface 9 row 9.7).
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:  # nosec B310
             if resp.status != 200:
                 raise TarballFetchError(
                     f"GitHub tarball API returned HTTP {resp.status} for "
@@ -149,10 +183,7 @@ def _fetch_tarball(
     extract_root = dest / "extracted"
     extract_root.mkdir()
     with tarfile.open(tar_path, mode="r:gz") as tar:
-        # filter="data" rejects: absolute paths, traversal (../), special
-        # files (devices, FIFOs), symlinks pointing outside the extract
-        # root. This is the load-bearing safety.
-        tar.extractall(path=extract_root, filter="data")  # type: ignore[arg-type]
+        _safe_extract(tar, extract_root)
 
     # Tarball extracts to a single top-level dir. Find it.
     children = [c for c in extract_root.iterdir() if c.is_dir()]

--- a/src/ciguard/app/factory.py
+++ b/src/ciguard/app/factory.py
@@ -8,16 +8,21 @@ service:
   - Scheduler from `scheduler.py` (idempotency + bounded queue + per-
     repo lock) attached to `app.state.scheduler` so the webhook
     handler reaches it via `request.app.state.scheduler.enqueue(...)`.
-  - Scan executor injected at startup. v0.10.0 ships a STUB executor
-    (returns a "scan-not-yet-implemented" result that still posts a
-    Check Run + PR comment so the receiver wiring is verifiable end-
-    to-end). v0.10.1 wires the real executor that clones the repo via
-    the installation token and runs `ciguard scan-repo` against it.
+  - Scan executor injected at startup. v0.11.1 default is the real
+    `clone_and_scan_executor`: fetches the repo tarball at head SHA via
+    the installation token, extracts under a `tempfile.TemporaryDirectory`,
+    runs `repo_scan.scan_repo(include_findings=True)` against it,
+    translates the result to the PR-comment-renderer shape. Tests
+    inject a stub by passing `scan_executor=` to `create_app()`.
 
-The stub is honest about its scope: every scan posts a comment that
-explicitly says "ciguard receiver wired; scan execution lands in
-v0.10.1" so installers can confirm the App is reachable without being
-misled into thinking they're getting real findings yet.
+History:
+  - v0.10.0 shipped the receiver wiring with `_stub_scan_executor`
+    (returned a placeholder result so Check Run + PR comment plumbing
+    was verifiable end-to-end without yet cloning repos).
+  - v0.11.1 replaces the default with `clone_and_scan_executor`. The
+    stub remains exported for tests + as a safety fallback for any
+    deployment that hasn't yet wired App credentials (the stub doesn't
+    need a token).
 """
 from __future__ import annotations
 
@@ -27,6 +32,7 @@ from typing import Any, AsyncIterator, Optional
 
 from fastapi import FastAPI
 
+from .clone_executor import clone_and_scan_executor
 from .scan_runner import run_scan
 from .scheduler import ScanJob, ScanScheduler
 from .webhook import router as webhook_router
@@ -34,15 +40,15 @@ from .webhook import router as webhook_router
 logger = logging.getLogger("ciguard.app.factory")
 
 
-# ---- Stub scan executor (v0.10.0) ------------------------------------------
+# ---- Stub scan executor (kept for tests + as a safety fallback) -----------
 
 
 async def _stub_scan_executor(job: ScanJob) -> dict[str, Any]:
-    """Returns a placeholder scan result so v0.10.0 can demonstrate
-    end-to-end webhook → Check Run + PR comment plumbing without yet
-    cloning repos or running real scans. Replaced in v0.10.1 by the
-    real executor (clone via installation token; run ciguard scan-repo
-    against the local checkout)."""
+    """Placeholder scan result for tests + deployments without App
+    credentials. v0.10.0 used this as the default; v0.11.1 promotes
+    `clone_and_scan_executor` to the default. Tests still inject this
+    via `create_app(scan_executor=_stub_scan_executor)` to keep
+    Check Run + PR comment plumbing tests independent of the network."""
     logger.info(
         "stub executor handling job (installation=%d repo=%s head=%s)",
         job.installation_id, job.repo_full_name, job.head_sha[:7],
@@ -52,9 +58,8 @@ async def _stub_scan_executor(job: ScanJob) -> dict[str, Any]:
         "grade": "A",
         "findings": [],
         "summary": (
-            "ciguard receiver wired; actual scan execution lands in "
-            "v0.10.1. The Check Run + PR comment plumbing on this PR "
-            "is real — only the rule-evaluation step is stubbed."
+            "ciguard receiver wired with stub executor. Inject a real "
+            "executor via create_app(scan_executor=...) for production."
         ),
     }
 
@@ -66,7 +71,7 @@ async def _stub_scan_executor(job: ScanJob) -> dict[str, Any]:
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan — start scheduler at app startup, drain on
     shutdown. Replaces the deprecated @app.on_event hooks."""
-    executor = getattr(app.state, "scan_executor", None) or _stub_scan_executor
+    executor = getattr(app.state, "scan_executor", None) or clone_and_scan_executor
 
     async def scan_fn(job: ScanJob) -> None:
         await run_scan(job, executor)
@@ -92,9 +97,10 @@ def create_app(
     """Build a FastAPI instance ready for `uvicorn` to serve.
 
     Args:
-      scan_executor: Optional injection point. Defaults to the v0.10.0
-        stub. Tests pass their own; v0.10.1 will pass a real
-        clone-and-scan executor.
+      scan_executor: Optional injection point. Defaults to
+        `clone_and_scan_executor` (v0.11.1, fetches tarball + runs
+        `repo_scan.scan_repo`). Tests pass `_stub_scan_executor` or a
+        custom mock to keep network-free.
     """
     app = FastAPI(
         title="ciguard GitHub App",

--- a/src/ciguard/repo_scan.py
+++ b/src/ciguard/repo_scan.py
@@ -98,6 +98,7 @@ def scan_repo(
     fail_on: Optional[str] = None,
     no_ignore_file: bool = False,
     follow_symlinks: bool = False,
+    include_findings: bool = False,
 ) -> Dict[str, Any]:
     """Discover and scan every pipeline file under `repo_path`.
 
@@ -113,6 +114,21 @@ def scan_repo(
                              or {error: ...} on parser failure)
 
     `fail_on` accepts None | "Critical" | "High" | "Medium" | "Low" | "Info".
+
+    When `include_findings=True`, additional fields are added:
+      - findings:           flat list across all files; each entry is a
+                            Finding `model_dump()` extended with the
+                            relative file path. Used by callers that need
+                            individual finding objects (the App's PR-comment
+                            renderer, baseline-delta diffing).
+      - risk_score:         the LOWEST per-file overall score (min — the
+                            worst pipeline gates the repo's posture).
+                            None if `files_scanned == 0`.
+      - grade:              the grade attached to the worst-score file.
+                            None if `files_scanned == 0`.
+
+    The default (`include_findings=False`) preserves the v0.9.x dict shape
+    that `ciguard scan-repo` CLI and the MCP `scan_repo` tool depend on.
     """
     repo_path = Path(repo_path).expanduser()
     if not repo_path.exists():
@@ -124,8 +140,11 @@ def scan_repo(
     files: List[Dict[str, Any]] = []
     by_severity: Dict[str, int] = {s.value: 0 for s in Severity}
     total_findings = 0
+    all_findings: List[Dict[str, Any]] = []
+    worst: Optional[tuple[float, str]] = None  # (score, grade) of lowest-scoring file
 
     for df in discovered:
+        rel_path = str(df.path.relative_to(repo_path))
         try:
             report = scan_one(
                 df.path,
@@ -135,7 +154,7 @@ def scan_repo(
             )
         except Exception as exc:
             files.append({
-                "path": str(df.path.relative_to(repo_path)),
+                "path": rel_path,
                 "platform": df.platform,
                 "error": str(exc),
             })
@@ -144,15 +163,27 @@ def scan_repo(
             sev = f.severity.value if hasattr(f.severity, "value") else str(f.severity)
             by_severity[sev] = by_severity.get(sev, 0) + 1
             total_findings += 1
-        files.append({
-            "path": str(df.path.relative_to(repo_path)),
+            if include_findings:
+                f_dict = f.model_dump(mode="json")
+                f_dict["file"] = rel_path
+                all_findings.append(f_dict)
+        file_entry: Dict[str, Any] = {
+            "path": rel_path,
             "platform": df.platform,
             "score": report.risk_score.overall,
             "grade": report.risk_score.grade,
             "findings_total": len(report.findings),
             "findings_by_severity": dict(report.summary["by_severity"]),
             "suppressed": len(report.suppressed),
-        })
+        }
+        if include_findings:
+            file_entry["findings"] = [
+                f.model_dump(mode="json") for f in report.findings
+            ]
+        files.append(file_entry)
+        score = report.risk_score.overall
+        if worst is None or score < worst[0]:
+            worst = (score, report.risk_score.grade)
 
     fails_threshold = False
     if fail_on and fail_on in SEVERITY_ORDER:
@@ -162,7 +193,7 @@ def scan_repo(
                 fails_threshold = True
                 break
 
-    return {
+    result: Dict[str, Any] = {
         "repo_path": str(repo_path),
         "files_scanned": len(files),
         "total_findings": total_findings,
@@ -171,3 +202,8 @@ def scan_repo(
         "fails_threshold": fails_threshold,
         "files": files,
     }
+    if include_findings:
+        result["findings"] = all_findings
+        result["risk_score"] = worst[0] if worst is not None else None
+        result["grade"] = worst[1] if worst is not None else None
+    return result

--- a/tests/test_app_clone_executor.py
+++ b/tests/test_app_clone_executor.py
@@ -1,0 +1,296 @@
+"""Tests for `ciguard.app.clone_executor`.
+
+Strategy: build a real .tar.gz from a tmp_path repo fixture in each test,
+then mock `urllib.request.urlopen` to return its bytes. That exercises:
+
+  - The streaming download loop (chunk size, byte cap)
+  - The tarfile filter='data' extraction
+  - The single-top-level-dir layout assertion
+  - The hand-off to `repo_scan.scan_repo(include_findings=True)`
+  - The result-dict translation
+
+Tokens are mocked so the tests never call out to GitHub.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ciguard.app import clone_executor
+from ciguard.app.scheduler import ScanJob
+
+
+# ---- Fixtures ---------------------------------------------------------------
+
+
+_GITLAB_BAD = """\
+stages: [build]
+
+build:
+  stage: build
+  image: ubuntu:latest
+  script:
+    - curl http://example.com/install.sh | sh
+"""
+
+
+def _make_repo_dir(root: Path) -> Path:
+    """Create a minimal scannable repo under `root` and return the path."""
+    src = root / "src-repo"
+    src.mkdir()
+    (src / ".gitlab-ci.yml").write_text(_GITLAB_BAD)
+    (src / "README.md").write_text("# test repo\n")
+    return src
+
+
+def _make_tarball(repo_dir: Path, top_level_name: str = "Jo-Jo98-ciguard-abc1234") -> bytes:
+    """Pack `repo_dir` into a .tar.gz that mirrors GitHub's tarball layout
+    (single top-level dir like `<owner>-<repo>-<sha7>/`)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        tar.add(str(repo_dir), arcname=top_level_name)
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    """Just enough urllib.HTTPResponse surface for `_fetch_tarball`."""
+
+    def __init__(self, body: bytes, status: int = 200):
+        self._buf = io.BytesIO(body)
+        self.status = status
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _make_scan_job(repo_full_name: str = "Jo-Jo98/ciguard-target") -> ScanJob:
+    return ScanJob(
+        installation_id=129208018,
+        repo_full_name=repo_full_name,
+        head_sha="abc1234abc1234abc1234abc1234abc1234abc1",
+        pr_number=42,
+    )
+
+
+# ---- _fetch_tarball ---------------------------------------------------------
+
+
+def test_fetch_tarball_extracts_to_single_top_level_dir(tmp_path: Path):
+    repo = _make_repo_dir(tmp_path)
+    tarball_bytes = _make_tarball(repo, top_level_name="Jo-Jo98-target-abc1234")
+    dest = tmp_path / "dl"
+    dest.mkdir()
+
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+        with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(tarball_bytes)):
+            extract_path = clone_executor._fetch_tarball(
+                installation_id=42, owner="Jo-Jo98", repo="target",
+                ref="abc1234abc1234abc1234abc1234abc1234abc1", dest=dest,
+            )
+
+    assert extract_path.is_dir()
+    assert extract_path.name == "Jo-Jo98-target-abc1234"
+    assert (extract_path / ".gitlab-ci.yml").exists()
+    assert (extract_path / ".gitlab-ci.yml").read_text() == _GITLAB_BAD
+
+
+def test_fetch_tarball_token_used_in_authorization_header_not_url(tmp_path: Path):
+    repo = _make_repo_dir(tmp_path)
+    tarball_bytes = _make_tarball(repo)
+    dest = tmp_path / "dl"; dest.mkdir()
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        return _FakeResponse(tarball_bytes)
+
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_secret_token_value"):
+        with patch.object(clone_executor.urllib.request, "urlopen", side_effect=fake_urlopen):
+            clone_executor._fetch_tarball(
+                installation_id=42, owner="Jo-Jo98", repo="target",
+                ref="abc1234", dest=dest,
+            )
+
+    assert "ghs_secret_token_value" not in captured["url"]
+    assert captured["url"].endswith("/repos/Jo-Jo98/target/tarball/abc1234")
+    auth = captured["headers"].get("Authorization", "")
+    assert auth == "token ghs_secret_token_value"
+
+
+def test_fetch_tarball_aborts_when_size_cap_exceeded(tmp_path: Path):
+    # Construct a tarball whose gzip-compressed size exceeds a tiny patched cap.
+    # We patch MAX_TARBALL_BYTES rather than building a 200MB+ tarball.
+    repo = _make_repo_dir(tmp_path)
+    tarball_bytes = _make_tarball(repo)
+    dest = tmp_path / "dl"; dest.mkdir()
+
+    with patch.object(clone_executor, "MAX_TARBALL_BYTES", 100):  # 100 bytes cap
+        with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+            with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(tarball_bytes)):
+                with pytest.raises(clone_executor.TarballTooLarge):
+                    clone_executor._fetch_tarball(
+                        installation_id=42, owner="o", repo="r", ref="abc",
+                        dest=dest,
+                    )
+
+
+def test_fetch_tarball_401_invalidates_token_cache(tmp_path: Path):
+    """Closes the THREAT_MODEL "Cached installation token used after revocation"
+    contract — when the API returns 401, the executor MUST purge the cached
+    token before re-raising so the next mint re-exchanges JWT."""
+    import urllib.error
+    dest = tmp_path / "dl"; dest.mkdir()
+    err = urllib.error.HTTPError(
+        url="http://x", code=401, msg="Unauthorized", hdrs=None, fp=io.BytesIO(b""),
+    )
+
+    invalidated = []
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_revoked"):
+        with patch.object(clone_executor.tokens, "invalidate_token", side_effect=lambda iid: invalidated.append(iid)):
+            with patch.object(clone_executor.urllib.request, "urlopen", side_effect=err):
+                with pytest.raises(clone_executor.TarballFetchError):
+                    clone_executor._fetch_tarball(
+                        installation_id=129208018, owner="o", repo="r", ref="abc",
+                        dest=dest,
+                    )
+
+    assert invalidated == [129208018]
+
+
+def test_fetch_tarball_unexpected_layout_raises(tmp_path: Path):
+    """If GitHub's tarball ever stops conforming to the single-top-level-dir
+    convention, fail loud rather than silently scanning the wrong path."""
+    # Build a tarball with TWO top-level dirs.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        a = tmp_path / "a"; a.mkdir(); (a / "f").write_text("a")
+        b = tmp_path / "b"; b.mkdir(); (b / "f").write_text("b")
+        tar.add(str(a), arcname="dir-a")
+        tar.add(str(b), arcname="dir-b")
+    weird_bytes = buf.getvalue()
+
+    dest = tmp_path / "dl"; dest.mkdir()
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+        with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(weird_bytes)):
+            with pytest.raises(clone_executor.TarballFetchError, match="unexpected tarball layout"):
+                clone_executor._fetch_tarball(
+                    installation_id=42, owner="o", repo="r", ref="abc",
+                    dest=dest,
+                )
+
+
+# ---- _to_app_result ---------------------------------------------------------
+
+
+def test_to_app_result_normal_case():
+    scan = {
+        "files_scanned": 2,
+        "total_findings": 3,
+        "risk_score": 65.0,
+        "grade": "C",
+        "findings": [
+            {"rule_id": "X-001", "severity": "High", "location": "build", "evidence": "..."},
+            {"rule_id": "Y-002", "severity": "Low", "location": "test", "evidence": "..."},
+            {"rule_id": "Z-003", "severity": "Info", "location": "global", "evidence": "..."},
+        ],
+    }
+    out = clone_executor._to_app_result(scan)
+    assert out["risk_score"] == 65.0
+    assert out["grade"] == "C"
+    assert len(out["findings"]) == 3
+    assert "Scanned 2 pipeline file(s)" in out["summary"]
+
+
+def test_to_app_result_empty_repo_yields_no_pipelines_marker():
+    scan = {"files_scanned": 0, "total_findings": 0, "findings": [], "risk_score": None, "grade": None}
+    out = clone_executor._to_app_result(scan)
+    assert out["risk_score"] == "—"
+    assert out["grade"] == "—"
+    assert out["findings"] == []
+    assert "did not find any pipeline files" in out["summary"]
+
+
+def test_to_app_result_error_case():
+    scan = {"error": "Path not found: /nonexistent"}
+    out = clone_executor._to_app_result(scan)
+    assert out["grade"] == "F"
+    assert out["findings"] == []
+    assert "Path not found" in out["summary"]
+
+
+# ---- clone_and_scan_executor (full path with mocks) -------------------------
+
+
+def test_clone_and_scan_executor_end_to_end(tmp_path: Path):
+    repo = _make_repo_dir(tmp_path)
+    tarball_bytes = _make_tarball(repo)
+    job = _make_scan_job()
+
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+        with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(tarball_bytes)):
+            result = asyncio.run(clone_executor.clone_and_scan_executor(job))
+
+    assert "findings" in result
+    assert "risk_score" in result
+    assert "grade" in result
+    assert "summary" in result
+    # Our fixture has known High-severity findings (mutable image tag +
+    # curl-pipe-sh), so we expect at least one.
+    assert len(result["findings"]) >= 1
+    severities = {f.get("severity") for f in result["findings"]}
+    # The fixture should produce something at High or above
+    assert any(s in {"High", "Critical"} for s in severities)
+
+
+def test_clone_and_scan_executor_cleans_temp_dir_on_success(tmp_path: Path):
+    """tempfile.TemporaryDirectory context manager handles this for us, but
+    we verify the contract by asserting no leaked dirs in tempfile.gettempdir."""
+    import tempfile as _tempfile
+    repo = _make_repo_dir(tmp_path)
+    tarball_bytes = _make_tarball(repo)
+    job = _make_scan_job()
+
+    pre = {p.name for p in Path(_tempfile.gettempdir()).glob("ciguard-app-*")}
+
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+        with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(tarball_bytes)):
+            asyncio.run(clone_executor.clone_and_scan_executor(job))
+
+    post = {p.name for p in Path(_tempfile.gettempdir()).glob("ciguard-app-*")}
+    assert post - pre == set(), f"leaked temp dirs: {post - pre}"
+
+
+def test_clone_and_scan_executor_cleans_temp_dir_on_fetch_failure(tmp_path: Path):
+    import tempfile as _tempfile
+    job = _make_scan_job()
+    pre = {p.name for p in Path(_tempfile.gettempdir()).glob("ciguard-app-*")}
+
+    with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
+        with patch.object(clone_executor.urllib.request, "urlopen", side_effect=ConnectionError("network down")):
+            with pytest.raises(Exception):
+                asyncio.run(clone_executor.clone_and_scan_executor(job))
+
+    post = {p.name for p in Path(_tempfile.gettempdir()).glob("ciguard-app-*")}
+    assert post - pre == set()
+
+
+def test_clone_and_scan_executor_rejects_malformed_repo_full_name():
+    job = ScanJob(
+        installation_id=42, repo_full_name="malformed-no-slash",
+        head_sha="abc1234abc1234abc1234abc1234abc1234abc1",
+        pr_number=None,
+    )
+    with pytest.raises(ValueError, match="malformed repo_full_name"):
+        asyncio.run(clone_executor.clone_and_scan_executor(job))

--- a/tests/test_app_clone_executor.py
+++ b/tests/test_app_clone_executor.py
@@ -108,7 +108,8 @@ def test_fetch_tarball_extracts_to_single_top_level_dir(tmp_path: Path):
 def test_fetch_tarball_token_used_in_authorization_header_not_url(tmp_path: Path):
     repo = _make_repo_dir(tmp_path)
     tarball_bytes = _make_tarball(repo)
-    dest = tmp_path / "dl"; dest.mkdir()
+    dest = tmp_path / "dl"
+    dest.mkdir()
     captured = {}
 
     def fake_urlopen(req, timeout):
@@ -134,7 +135,8 @@ def test_fetch_tarball_aborts_when_size_cap_exceeded(tmp_path: Path):
     # We patch MAX_TARBALL_BYTES rather than building a 200MB+ tarball.
     repo = _make_repo_dir(tmp_path)
     tarball_bytes = _make_tarball(repo)
-    dest = tmp_path / "dl"; dest.mkdir()
+    dest = tmp_path / "dl"
+    dest.mkdir()
 
     with patch.object(clone_executor, "MAX_TARBALL_BYTES", 100):  # 100 bytes cap
         with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
@@ -151,7 +153,8 @@ def test_fetch_tarball_401_invalidates_token_cache(tmp_path: Path):
     contract — when the API returns 401, the executor MUST purge the cached
     token before re-raising so the next mint re-exchanges JWT."""
     import urllib.error
-    dest = tmp_path / "dl"; dest.mkdir()
+    dest = tmp_path / "dl"
+    dest.mkdir()
     err = urllib.error.HTTPError(
         url="http://x", code=401, msg="Unauthorized", hdrs=None, fp=io.BytesIO(b""),
     )
@@ -175,13 +178,18 @@ def test_fetch_tarball_unexpected_layout_raises(tmp_path: Path):
     # Build a tarball with TWO top-level dirs.
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        a = tmp_path / "a"; a.mkdir(); (a / "f").write_text("a")
-        b = tmp_path / "b"; b.mkdir(); (b / "f").write_text("b")
+        a = tmp_path / "a"
+        a.mkdir()
+        (a / "f").write_text("a")
+        b = tmp_path / "b"
+        b.mkdir()
+        (b / "f").write_text("b")
         tar.add(str(a), arcname="dir-a")
         tar.add(str(b), arcname="dir-b")
     weird_bytes = buf.getvalue()
 
-    dest = tmp_path / "dl"; dest.mkdir()
+    dest = tmp_path / "dl"
+    dest.mkdir()
     with patch.object(clone_executor.tokens, "get_installation_token", return_value="ghs_fake"):
         with patch.object(clone_executor.urllib.request, "urlopen", return_value=_FakeResponse(weird_bytes)):
             with pytest.raises(clone_executor.TarballFetchError, match="unexpected tarball layout"):

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -108,6 +108,60 @@ class TestScanRepoHelper:
         # Sanity: SEVERITY_ORDER drives the threshold logic. Lock the order.
         assert SEVERITY_ORDER == ["Critical", "High", "Medium", "Low", "Info"]
 
+    # ---- include_findings contract (v0.11.1 — App scan executor) -----------
+
+    def test_include_findings_default_off_preserves_v0_9_dict_shape(self, tmp_path):
+        # Locks the v0.9.x callers (CLI scan-repo, MCP scan_repo tool) against
+        # accidental shape drift when the App-context fields land.
+        _make_mixed_repo(tmp_path)
+        result = scan_repo(tmp_path, offline=True)
+        assert "findings" not in result
+        assert "risk_score" not in result
+        assert "grade" not in result
+        for file_entry in result["files"]:
+            assert "findings" not in file_entry  # per-file findings list also opt-in
+
+    def test_include_findings_attaches_flat_list_and_aggregate_score(self, tmp_path):
+        _make_mixed_repo(tmp_path)
+        result = scan_repo(tmp_path, offline=True, include_findings=True)
+        # Flat list across all files
+        assert "findings" in result
+        assert isinstance(result["findings"], list)
+        assert len(result["findings"]) == result["total_findings"]
+        # Each finding is a dict with the load-bearing fields the App's
+        # PR-comment renderer reads (severity, rule_id, location, evidence,
+        # message-equivalent name/description).
+        for f in result["findings"]:
+            assert "rule_id" in f
+            assert "severity" in f
+            assert "location" in f
+            assert "evidence" in f
+            assert "file" in f  # added by scan_repo, not present on the model
+        # Per-file findings ALSO attached (the App may want per-file rendering)
+        for file_entry in result["files"]:
+            if "error" in file_entry:
+                continue
+            assert "findings" in file_entry
+            assert len(file_entry["findings"]) == file_entry["findings_total"]
+        # Aggregate risk_score = min over per-file scores (worst pipeline gates the repo)
+        per_file_scores = [
+            f["score"] for f in result["files"] if "error" not in f
+        ]
+        assert result["risk_score"] == min(per_file_scores)
+        # Grade matches the worst-scoring file
+        worst_file = min(
+            (f for f in result["files"] if "error" not in f),
+            key=lambda f: f["score"],
+        )
+        assert result["grade"] == worst_file["grade"]
+
+    def test_include_findings_on_empty_repo_returns_none_score(self, tmp_path):
+        result = scan_repo(tmp_path, offline=True, include_findings=True)
+        assert result["files_scanned"] == 0
+        assert result["findings"] == []
+        assert result["risk_score"] is None
+        assert result["grade"] is None
+
 
 # ---- CLI integration -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two-commit PR that lands the real scan executor for the GitHub App, replacing v0.10.0's stub:

- **Commit 1** (`b714210`) — `repo_scan.scan_repo()` gains an `include_findings: bool = False` keyword. Default preserves v0.9.x dict shape (CLI scan-repo + MCP scan_repo tool unchanged). With it on: per-finding `model_dump()` list at top-level + per-file, plus aggregate `risk_score`/`grade` derived from the worst-scoring file.
- **Commit 2** (`c84453d`) — new `src/ciguard/app/clone_executor.py` that mints an installation token, fetches the repo tarball at head SHA via `GET /repos/{o}/{r}/tarball/{ref}`, extracts under `tempfile.TemporaryDirectory()` with `tarfile.extractall(filter='data')`, hands to `repo_scan.scan_repo(include_findings=True)`, and translates the result to the PR-comment-renderer shape. Wired into `factory.py` as the default; stub kept as test injection point.

## Why tarball not git-clone

- No `git` binary in deploy image — smaller container, fewer CVEs to patch
- Single HTTP request vs. multi-stage clone + fetch + checkout
- GitHub's tarball is auto-derived from the ref — no "did the shallow clone include this SHA?" edge case
- Smaller transfer (no `.git/objects` metadata)

## Threat-model controls landed

| Threat-model row | Control |
|---|---|
| Surface 9 — Webhook handler DoS — large payload / slow scan | 200 MB streaming size cap (`TarballTooLarge`); aborts mid-download |
| Surface 9 — Installation token leakage in logs | Token in `Authorization` header only; never in URL — never appears in process listings or URL-capturing logs |
| Surface 9 — Multi-tenant baseline.json bleed (archive-injection sub-row) | `tarfile.extractall(filter='data')` (Python 3.12+ safe-filter) rejects absolute paths, `..` traversal, special files |
| Surface 9 — Cached installation token used after revocation | 401 from tarball API → `tokens.invalidate_token(install_id)` before re-raise |

The Python 3.12+ `filter='data'` requirement is asserted at module import time so an inadvertent downgrade to 3.11 fails loudly.

## Out of scope (deferred to subsequent PRs)

- Subprocess-isolation of the scanner itself (defence-in-depth against parser exploits in attacker-controlled YAML / Jenkinsfile content). Parsers are already hardened (yaml.SafeLoader, Fuzz-#18 RecursionError wrap), so this is hardening, not a current risk.
- Per-installation rate-limit / quota.
- Documentation in DEPLOYMENT.md.

## Test plan

- [x] `pytest tests/test_repo_scan.py` — 15 PASS (12 existing + 3 new for `include_findings`)
- [x] `pytest tests/test_app_clone_executor.py` — 12 PASS (tarball extraction, token-in-header-not-URL, size cap, 401 cache invalidate, unexpected-layout fail-loud, result-shape translation × 3, end-to-end, temp-dir cleanup × 2, malformed repo name)
- [x] `pytest tests/test_app_factory.py tests/test_app_scan_runner.py` — 14 PASS (existing tests unaffected by default-executor swap)
- [x] `pytest` (full suite) — **977 passed, 5 skipped** (was 962 baseline → +3 commit 1 → +12 commit 2)
- [ ] CI green on this PR

## Release plan

Merge → bump version to 0.11.1 (templates + `pyproject.toml`) → tag → `gh release create` triggers PyPI + GHCR + Sigstore + SBOM lanes already wired in `_release.yml`. Cycle 1.5's F-9.6.1 fix (already on main as `65ee687`) ships in the same release.