### PR TITLE
chore(release): bump version to 0.11.1 in pyproject.toml + templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciguard"
-version = "0.11.0"
+version = "0.11.1"
 description = "Static security auditor for CI/CD pipelines — now with a Model Context Protocol server (`pip install 'ciguard[mcp]'`) exposing scan / scan_repo / explain_rule / diff_baseline / list_rules to Claude Desktop / Claude Code / Cursor. Plus .ciguardignore rationale-required suppression, baseline / delta reports, EOL-aware image checks, GitHub Actions CVE lookups across GitLab CI, GitHub Actions, and Jenkins Pipelines. Pre-commit hook + CIGUARD_MCP_DISABLED enterprise gate."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/templates/github-actions/ciguard-scan-baseline.yml
+++ b/templates/github-actions/ciguard-scan-baseline.yml
@@ -11,7 +11,7 @@
 #      Security tab and on PR diffs.
 #
 # To bootstrap your baseline:
-#   pip install ciguard==0.11.0
+#   pip install ciguard==0.11.1
 #   ciguard scan-repo . --output .ciguard/baseline-snapshot.json
 #   ciguard scan --input .gitlab-ci.yml --baseline .ciguard/baseline.json --update-baseline
 #   git add .ciguard/baseline.json && git commit -m "chore: ciguard baseline"
@@ -43,7 +43,7 @@ jobs:
           cache: pip
 
       - name: Install ciguard (pinned)
-        run: pip install --upgrade pip && pip install ciguard==0.11.0
+        run: pip install --upgrade pip && pip install ciguard==0.11.1
 
       - name: Scan repository against baseline
         # `--fail-on High` exits non-zero on any High+ finding — combined

--- a/templates/github-actions/ciguard-scan-repo.yml
+++ b/templates/github-actions/ciguard-scan-repo.yml
@@ -33,7 +33,7 @@ jobs:
           cache: pip
 
       - name: Install ciguard (pinned)
-        run: pip install --upgrade pip && pip install ciguard==0.11.0
+        run: pip install --upgrade pip && pip install ciguard==0.11.1
 
       - name: Auto-discover and scan every pipeline file
         run: |

--- a/templates/github-actions/ciguard-scan.yml
+++ b/templates/github-actions/ciguard-scan.yml
@@ -31,7 +31,7 @@ jobs:
           cache: pip
 
       - name: Install ciguard (pinned)
-        run: pip install --upgrade pip && pip install ciguard==0.11.0
+        run: pip install --upgrade pip && pip install ciguard==0.11.1
 
       - name: Scan repository
         run: ciguard scan-repo . --output ciguard-results.json --offline

--- a/templates/gitlab-ci/ciguard.gitlab-ci.yml
+++ b/templates/gitlab-ci/ciguard.gitlab-ci.yml
@@ -9,7 +9,7 @@
 # repo, exposes the JSON report as a job artifact, and can be wired
 # into the pipeline as a gate stage by changing `allow_failure: true`.
 #
-# Bump the version pin (`ciguard==0.11.0`) when you want to upgrade.
+# Bump the version pin (`ciguard==0.11.1`) when you want to upgrade.
 
 stages:
   - test
@@ -22,7 +22,7 @@ ciguard:
     # bypass network SCA lookups.
     CIGUARD_OFFLINE: "0"
   before_script:
-    - pip install --quiet ciguard==0.11.0
+    - pip install --quiet ciguard==0.11.1
   script:
     - |
       OFFLINE_FLAG=""

--- a/templates/jenkins/Jenkinsfile.ciguard
+++ b/templates/jenkins/Jenkinsfile.ciguard
@@ -26,7 +26,7 @@ pipeline {
                         docker run --rm \
                             -v "$WORKSPACE":/repo \
                             -w /repo \
-                            ghcr.io/jo-jo98/ciguard:v0.11.0 \
+                            ghcr.io/jo-jo98/ciguard:v0.11.1 \
                             scan-repo /repo \
                                 --output /repo/ciguard-results.json \
                                 --fail-on High \


### PR DESCRIPTION
## Summary

Pre-release commit for v0.11.1. Bumps the package version + the 7 template pins that `test_templates.py` asserts must match `pyproject.toml`.

| File | Bump |
|---|---|
| `pyproject.toml` | `version = "0.11.0"` → `"0.11.1"` |
| `templates/github-actions/ciguard-scan-baseline.yml` | 2 pins |
| `templates/github-actions/ciguard-scan-repo.yml` | 1 pin |
| `templates/github-actions/ciguard-scan.yml` | 1 pin |
| `templates/gitlab-ci/ciguard.gitlab-ci.yml` | 2 pins |
| `templates/jenkins/Jenkinsfile.ciguard` | 1 pin (GHCR image tag) |

CHANGELOG entry lands in the release commit produced by `scripts/release.sh` once this PR merges (matches the v0.11.0 prior pattern at commit f30512c).

## What v0.11.1 ships

Pulled from main since v0.11.0 (`4f74859`):

```
71a614b  fix(app): per-member tar.extract for CodeQL py/tarslip
d52a119  docs: drop section-sign character (§ -> 'Section ')
ca999e7  docs: add DEPLOYMENT.md operator guide for v0.11.1 GitHub App
218439d  fix(app): clone_executor — drop 3.12+ assert, add B310 nosec, lint cleanups
57f4692  feat(app): clone_and_scan_executor — real scan executor for v0.11.1
cfe2094  feat(repo_scan): include_findings flag for App scan-executor consumption
65ee687  fix(app): strip NUL + C0 control chars in _safe_md_inline (Cycle 1.5 F-9.6.1)
```

The headline change is **`clone_and_scan_executor`** replacing v0.10.0's stub — the App receiver now genuinely fetches the repo tarball at head SHA, scans it, and reports findings. The Cycle 1.5 self-pentest closed with two minor findings; F-9.6.1 (Low, NUL-byte sanitiser) is fixed in this release; F-9.1.1 (Info, OWS in signature header) tracked under issue [#23](https://github.com/Jo-Jo98/ciguard/issues/23).

## Test plan

- [x] `pytest` (full suite) — 977 passed, 5 skipped
- [x] `ruff check src tests scripts` — All checks passed
- [x] `bandit -r src/ --severity-level medium --confidence-level medium` — exit 0
- [ ] CI green on this PR

## After merge

1. On main, write CHANGELOG.md `## [0.11.1]` entry
2. Run `./scripts/release.sh 0.11.1 "release: v0.11.1 — App real scan executor + DEPLOYMENT.md + Cycle 1.5 F-9.6.1 fix"`
3. `git push origin main && git push origin v0.11.1` triggers PyPI + GHCR + Sigstore + SBOM + PEP 740 lanes